### PR TITLE
resolves #10 - gameSession recordings

### DIFF
--- a/src/GameLogic/DataStructures/Entities.ts
+++ b/src/GameLogic/DataStructures/Entities.ts
@@ -22,8 +22,18 @@ export class Entities {
 	}
 
 	public getPlayer(): Protagonist | undefined {
-		// @todo Once we have projections this will have to be updated to return the correct player
-		return this.getFirstEntityOfType(EntityType.Protagonist) as Protagonist;
+		const protagonists = this.getEntitiesOfType(EntityType.Protagonist) as Protagonist[];
+		let result = undefined;
+		for (let i = 0; i < protagonists.length; i++) {
+			if (protagonists[i].isPlayerControlled) {
+				if (!result) {
+					result = protagonists[i];
+				} else {
+					throw new Error('More than one player-controlled Protagonist was found.');
+				}
+			}
+		}
+		return result;
 	}
 
 	public get entities(): readonly Entity[] {

--- a/src/GameLogic/DataStructures/Entities.ts
+++ b/src/GameLogic/DataStructures/Entities.ts
@@ -23,17 +23,11 @@ export class Entities {
 
 	public getPlayer(): Protagonist | undefined {
 		const protagonists = this.getEntitiesOfType(EntityType.Protagonist) as Protagonist[];
-		let result = undefined;
-		for (let i = 0; i < protagonists.length; i++) {
-			if (protagonists[i].isPlayerControlled) {
-				if (!result) {
-					result = protagonists[i];
-				} else {
-					throw new Error('More than one player-controlled Protagonist was found.');
-				}
-			}
+		const result = protagonists.filter(x => x.isPlayerControlled);
+		if (result.length > 1) {
+			throw new Error('More than one player-controlled Protagonist was found.');
 		}
-		return result;
+		return result.pop();
 	}
 
 	public get entities(): readonly Entity[] {

--- a/src/GameLogic/Entities/Protagonist.ts
+++ b/src/GameLogic/Entities/Protagonist.ts
@@ -16,12 +16,16 @@ export class Protagonist implements Entity {
 
 	public movesQueue: ActionSequence;
 
-	constructor(isPlayerControlled = true) {
+	constructor(isPlayerControlled = true, movesQueue: ActionSequence = new ActionSequence()) {
 		this.type = EntityType.Protagonist;
 		this.x = 0;
 		this.y = 0;
 		this.isPlayerControlled = isPlayerControlled;
-		this.movesQueue = new ActionSequence();
+		if (isPlayerControlled) {
+			this.movesQueue = new ActionSequence();
+		} else {
+			this.movesQueue = movesQueue;
+		}
 	}
 
 	public update(level: Level): void {

--- a/test/GameLogic/Entities.test.ts
+++ b/test/GameLogic/Entities.test.ts
@@ -152,4 +152,48 @@ describe('GameLogic.DataStructures.Entities', () => {
 			assert.equal(entities.getFirstEntityOfType(EntityType.Protagonist), protagonist2);
 		});
 	});
+
+	describe('getPlayer', () => {
+		it('Returns undefined if no player-controlled Protagonist exists', () => {
+			//Arrange
+			const entities = new Entities();
+			const protagonist1 = new Protagonist(false);
+			const protagonist2 = new Protagonist(false);
+
+			//Act
+			entities.addEntity(protagonist1);
+			entities.addEntity(protagonist2);
+
+			//Assert
+			assert.equal(entities.getPlayer(), undefined);
+		});
+
+		it('Returns the entity if exactly one player-controlled Protagonist exists', () => {
+			//Arrange
+			const entities = new Entities();
+			const protagonist1 = new Protagonist(false);
+			const protagonist2 = new Protagonist(true);
+
+			//Act
+			entities.addEntity(protagonist1);
+			entities.addEntity(protagonist2);
+
+			//Assert
+			assert.equal(entities.getPlayer(), protagonist2);
+		});
+
+		it('Throws an error if more than one player-controlled Protagonist exists', () => {
+			//Arrange
+			const entities = new Entities();
+			const protagonist1 = new Protagonist(true);
+			const protagonist2 = new Protagonist(true);
+
+			//Act
+			entities.addEntity(protagonist1);
+			entities.addEntity(protagonist2);
+
+			//Assert
+			assert.throws(() => entities.getPlayer(), 'More than one player-controlled Protagonist was found.');
+		});
+	});
 });

--- a/test/GameLogic/GameSession.test.ts
+++ b/test/GameLogic/GameSession.test.ts
@@ -1,0 +1,94 @@
+import 'mocha';
+import {assert} from 'chai';
+import {ActionSequence} from '../../src/GameLogic/DataStructures/ActionSequence';
+import {GameSession} from '../../src/GameLogic/GameSession';
+import {LevelConfig, Level} from '../../src/GameLogic/Level';
+import {EntityType} from '../../src/GameLogic/Enums';
+import {Protagonist} from '../../src/GameLogic/Entities/Protagonist';
+
+describe('GameLogic.GameSession', () => {
+	describe('loadLevel', () => {
+		const levelConfig: LevelConfig = {
+			width: 20,
+			height: 20,
+			playerStartX: 10,
+			playerStartY: 10,
+		};
+
+		it('Adds a player-controlled protagonist to the level.', () => {
+			//Arrange
+			const level = new Level(levelConfig);
+			const gameSession = new GameSession();
+
+			//Act
+			gameSession.loadLevel(level);
+
+			//Assert
+			assert.exists(level.entities.getPlayer());
+		});
+
+		it('Adds only one protagonist if recordings is empty.', () => {
+			//Arrange
+			const level = new Level(levelConfig);
+			const gameSession = new GameSession();
+
+			//Act
+			gameSession.loadLevel(level);
+
+			//Assert
+			assert.equal(level.entities.getEntitiesOfType(EntityType.Protagonist).length, 1);
+		});
+
+		it('Adds 2 protagonists if recordings has one entry.', () => {
+			//Arrange
+			const level = new Level(levelConfig);
+			const gameSession = new GameSession();
+
+			//Act
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.loadLevel(level);
+
+			//Assert
+			assert.equal(level.entities.getEntitiesOfType(EntityType.Protagonist).length, 2);
+		});
+
+		it('Adds X + 1 protagonists if recordings has X entries.', () => {
+			//Arrange
+			const level = new Level(levelConfig);
+			const gameSession = new GameSession();
+
+			//Act
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.loadLevel(level);
+
+			//Assert
+			assert.equal(level.entities.getEntitiesOfType(EntityType.Protagonist).length, 6);
+		});
+
+		it('Adds X not player-controlled protagonists if recordings has X entries.', () => {
+			//Arrange
+			const level = new Level(levelConfig);
+			const gameSession = new GameSession();
+
+			//Act
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.recordings.push(new ActionSequence());
+			gameSession.loadLevel(level);
+
+			//Assert
+			const result = level.entities.getEntitiesOfType(EntityType.Protagonist) as Protagonist[];
+			let count = 0;
+			result.forEach(protagonist => {
+				if (!protagonist.isPlayerControlled) {
+					count++;
+				}
+			});
+			assert.equal(count, 3);
+		});
+	});
+});


### PR DESCRIPTION
- Adds ability for gameSession to store recordings
- Adds a not-player-controlled protagonist for each recording
- Updates Entities.getPlayer to return correct protagonist
- Entities.getPlayer double-checks that no more than one player-controlled protagonist exists, and throws a fatal error if this is not the case.