### PR TITLE
Add water that removes protagonists when entered

### DIFF
--- a/src/GameLogic/Entities/Protagonist.ts
+++ b/src/GameLogic/Entities/Protagonist.ts
@@ -45,9 +45,6 @@ export class Protagonist implements Entity {
 
 		if (level.tilesFloor.get(this.x, this.y) == FloorType.Water) {
 			level.entities.removeEntity(this);
-			if (this.isPlayerControlled) {
-				// @ todo figure out how to reset the level if this is the player-controlled protagonist
-			}
 		}
 	}
 

--- a/src/GameLogic/Entities/Protagonist.ts
+++ b/src/GameLogic/Entities/Protagonist.ts
@@ -42,6 +42,13 @@ export class Protagonist implements Entity {
 			this.x += direction.x;
 			this.y += direction.y;
 		}
+
+		if (level.tilesFloor.get(this.x, this.y) == FloorType.Water) {
+			level.entities.removeEntity(this);
+			if (this.isPlayerControlled) {
+				// @ todo figure out how to reset the level if this is the player-controlled protagonist
+			}
+		}
 	}
 
 	public clone(): Protagonist {
@@ -61,7 +68,7 @@ export class Protagonist implements Entity {
 
 		const floor = level.tilesFloor.get(newX, newY);
 
-		if (floor !== FloorType.FloorTile) {
+		if (floor == FloorType.Wall) {
 			return false;
 		}
 

--- a/src/GameLogic/Enums.ts
+++ b/src/GameLogic/Enums.ts
@@ -19,7 +19,8 @@ export enum EntityType {
 
 export enum FloorType {
 	FloorTile = 0,
-	Wall = 1
+	Wall = 1,
+	Water = 2
 }
 
 const directionToActionMap: Hashmap<PlayerAction> = {};

--- a/src/Scenes/GameScene/LevelRenderer.ts
+++ b/src/Scenes/GameScene/LevelRenderer.ts
@@ -48,9 +48,7 @@ export class LevelRenderer extends PIXI.Sprite {
 		for (let x = 0; x < level.width; x++) {
 			for (let y = 0; y < level.height; y++) {
 				const sprite = this.floorTiles.get(x, y) ?? new PIXI.Sprite();
-				sprite.texture = level.tilesFloor.get(x, y) === FloorType.Wall // @todo magic texture selection
-					? this._textureFactory.getTile(GfxConstants.InitialTileset, 1, 3)
-					: this._textureFactory.getTile(GfxConstants.InitialTileset, 3, 0);
+				sprite.texture = this.getFloorTypeSprite(level.tilesFloor.get(x, y));
 
 				if (!sprite.parent) {
 					this.floorTiles.set(x, y, sprite);
@@ -81,6 +79,18 @@ export class LevelRenderer extends PIXI.Sprite {
 
 		while (level.entities.length < this.entities.length) {
 			this.entities.pop()?.destroy();
+		}
+	}
+
+	private getFloorTypeSprite(floorType: FloorType): PIXI.Texture {
+		switch (floorType) {
+			case FloorType.Wall:
+				return this._textureFactory.getTile(GfxConstants.InitialTileset, 1, 3);
+			case FloorType.Water:
+				return this._textureFactory.getTile(GfxConstants.InitialTileset, 1, 4);
+			case FloorType.FloorTile:
+			default:
+				return this._textureFactory.getTile(GfxConstants.InitialTileset, 3, 0);
 		}
 	}
 }

--- a/src/Scenes/GameScene/LevelRenderer.ts
+++ b/src/Scenes/GameScene/LevelRenderer.ts
@@ -48,7 +48,7 @@ export class LevelRenderer extends PIXI.Sprite {
 		for (let x = 0; x < level.width; x++) {
 			for (let y = 0; y < level.height; y++) {
 				const sprite = this.floorTiles.get(x, y) ?? new PIXI.Sprite();
-				sprite.texture = this.getFloorTypeSprite(level.tilesFloor.get(x, y));
+				sprite.texture = this.getFloorTypeTexture(level.tilesFloor.get(x, y));
 
 				if (!sprite.parent) {
 					this.floorTiles.set(x, y, sprite);
@@ -82,7 +82,7 @@ export class LevelRenderer extends PIXI.Sprite {
 		}
 	}
 
-	private getFloorTypeSprite(floorType: FloorType): PIXI.Texture {
+	private getFloorTypeTexture(floorType: FloorType): PIXI.Texture {
 		switch (floorType) {
 			case FloorType.Wall:
 				return this._textureFactory.getTile(GfxConstants.InitialTileset, 1, 3);

--- a/src/Scenes/GameScene/SessionController.ts
+++ b/src/Scenes/GameScene/SessionController.ts
@@ -18,8 +18,7 @@ export class SessionController {
 	}
 
 	public restartAndSaveRecording(): void {
-		const player = this._session.level.entities.getPlayer();
-		player && this._session.registerRecording(player.movesQueue.copy());
+		this._session.registerRecording(this._session.actionRecorder.end());
 		this._session.resetLevel();
 	}
 

--- a/src/Scenes/InitializerScene.ts
+++ b/src/Scenes/InitializerScene.ts
@@ -42,6 +42,9 @@ export class InitializerScene implements Scene {
 		level.tilesFloor.set(2, 2, FloorType.Wall);
 		level.tilesFloor.set(7, 3, FloorType.Wall);
 		level.tilesFloor.set(15, 17, FloorType.Wall);
+		level.tilesFloor.set(6, 14, FloorType.Water);
+		level.tilesFloor.set(8, 12, FloorType.Water);
+		level.tilesFloor.set(15, 4, FloorType.Water);
 
 		const session = new GameSession(level);
 

--- a/test/GameLogic/e2e/ActionRecording.test.ts
+++ b/test/GameLogic/e2e/ActionRecording.test.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import {assert} from 'chai';
 import {SessionPlayer} from '../helpers/SessionPlayer';
 import {TestLevelBuilder} from '../helpers/TestLevelBuilder';
-import {PlayerAction} from '../../../src/GameLogic/Enums';
+import {PlayerAction, FloorType} from '../../../src/GameLogic/Enums';
 
 describe('GameLogic.e2e - action recording', () => {
 	it('Recording should return correct move sequence when recording ends', () => {
@@ -24,5 +24,26 @@ describe('GameLogic.e2e - action recording', () => {
 
 		//Assert
 		assert.deepEqual(result, actions);
+	});
+
+	it('Moves should not be recorded when there is no player', () => {
+		//Arrange
+		const actions: PlayerAction[] = [
+			PlayerAction.MoveUp,
+			PlayerAction.MoveUp,
+			PlayerAction.MoveUp,
+			PlayerAction.MoveUp,
+			PlayerAction.MoveUp,
+		];
+
+		//Act
+		const [session, , ] = SessionPlayer.play(
+			TestLevelBuilder.newLevel().plotFloor(10, 8, FloorType.Water),
+			actions
+		);
+		const result = session.actionRecorder.end().actions;
+
+		//Assert
+		assert.deepEqual(result, [PlayerAction.MoveUp, PlayerAction.MoveUp]);
 	});
 });

--- a/test/GameLogic/e2e/floorInteraction/WaterFloor.test.ts
+++ b/test/GameLogic/e2e/floorInteraction/WaterFloor.test.ts
@@ -1,0 +1,16 @@
+import 'mocha';
+import {assert} from 'chai';
+import {FloorType, PlayerAction} from '../../../../src/GameLogic/Enums';
+import {SessionPlayer} from '../../helpers/SessionPlayer';
+import {TestLevelBuilder} from '../../helpers/TestLevelBuilder';
+
+describe('GameLogic.e2e - Water floor', () => {
+	it('Protagonist should be removed when moving onto water', () => {
+		const [, level] = SessionPlayer.play(
+			TestLevelBuilder.newLevel().plotFloor(10, 9, FloorType.Water),
+			PlayerAction.MoveUp,
+		);
+
+		assert.isUndefined(level.entities.getPlayer());
+	});
+});


### PR DESCRIPTION
- Adds new water floor tile.
- Protagonist is removed if they enter a water tile.
- ActionRecorder stops recording moves if the player is removed.