### PR TITLE
Fix a bug where the next projection move effect sometimes has weird a…

### DIFF
--- a/src/Scenes/GameScene/Renderers/Effects/NextProjectionMoveEffect.ts
+++ b/src/Scenes/GameScene/Renderers/Effects/NextProjectionMoveEffect.ts
@@ -65,6 +65,8 @@ export class NextProjectionMoveEffect extends PIXI.Sprite implements Effect {
 
 		this._fromX = projection.x * Constants.TileWidth;
 		this._fromY = projection.y * Constants.TileHeight;
+		this.x = this._fromX;
+		this.y = this._fromY;
 
 		const nextAction = projection.movesQueue.peek();
 


### PR DESCRIPTION
…rtifacts - was caused by the position of the effect not being set on the initialization, only after the first update call